### PR TITLE
closes #59 and closes #2 via feature/#59-style-new-project

### DIFF
--- a/client/src/Form/LabelledTagInput.js
+++ b/client/src/Form/LabelledTagInput.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import TagsInput from 'react-tagsinput';
 import 'react-tagsinput/react-tagsinput.css';
+import './LabelledTagInput.css';
 
 const LabelledTagInput = (props) => {
   return (
@@ -12,7 +13,9 @@ const LabelledTagInput = (props) => {
           value={props.value} 
           onChange={props.onChange}
           disabled={props.disabled}
+          aria-describedby="taginput-help"
         />
+        <small className="form-text text-muted text-left LabelledTagInput_Help" id="taginput-help">Use Tab or Enter to add your tag to the list</small>
       </label>
     </div>
   );

--- a/client/src/Form/LabelledTagInput.js
+++ b/client/src/Form/LabelledTagInput.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import TagsInput from 'react-tagsinput';
-import 'react-tagsinput/react-tagsinput.css';
 import './LabelledTagInput.css';
 
 const LabelledTagInput = (props) => {

--- a/client/src/Form/LabelledTagInput.scss
+++ b/client/src/Form/LabelledTagInput.scss
@@ -1,3 +1,55 @@
 .LabelledTagInput_Help {
-  padding-left: 11px; // to align with the TagsInput
+  padding-left: 11px; /* to align with the TagsInput */
+}
+
+/*
+TagsInput classes
+Copied from https://github.com/olahol/react-tagsinput/blob/master/react-tagsinput.css
+for customising
+*/
+.react-tagsinput {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  overflow: hidden;
+  padding-left: 5px;
+  padding-top: 5px;
+}
+
+.react-tagsinput--focused {
+  border-color: #a5d24a;
+}
+
+.react-tagsinput-tag {
+  background-color: #cde69c;
+  border-radius: 2px;
+  border: 1px solid #a5d24a;
+  color: #638421;
+  display: inline-block;
+  font-family: sans-serif;
+  font-weight: 400;
+  margin-bottom: 5px;
+  margin-right: 5px;
+  padding: 3px 5px;
+}
+
+.react-tagsinput-remove {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.react-tagsinput-tag a::before {
+  content: " ×";
+}
+
+.react-tagsinput-input {
+  background: transparent;
+  border: 0;
+  color: #777;
+  font-family: sans-serif;
+  font-weight: 400;
+  margin-bottom: 6px;
+  margin-top: 1px;
+  outline: none;
+  padding: 3px 5px;
+  width: 80px;
 }

--- a/client/src/Form/LabelledTagInput.scss
+++ b/client/src/Form/LabelledTagInput.scss
@@ -1,0 +1,3 @@
+.LabelledTagInput_Help {
+  padding-left: 11px; // to align with the TagsInput
+}

--- a/client/src/Form/LabelledTagInput.test.js
+++ b/client/src/Form/LabelledTagInput.test.js
@@ -11,9 +11,10 @@ describe('LabelledTagInput', () => {
     expect(wrapper.hasClass('LabelledTagInput')).toBe(true);
     expect(wrapper.children()).toHaveLength(1);
     expect(wrapper.childAt(0).type()).toEqual('label');
-    expect(wrapper.childAt(0).children()).toHaveLength(2);
+    expect(wrapper.childAt(0).children()).toHaveLength(3);
     expect(wrapper.childAt(0).childAt(0).type()).toEqual('div');
     expect(wrapper.childAt(0).childAt(1).type()).toEqual(TagsInput);
+    expect(wrapper.childAt(0).childAt(2).type()).toEqual('small');
   });
 
   test('It displays text in the label', () => {

--- a/client/src/Form/LabelledTextarea.js
+++ b/client/src/Form/LabelledTextarea.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
 const LabelledTextarea = (props) => {
+  const { inputId, label, inputText, onChange, disabled, labelProps, ...other } = props;
   return (
     <div className="LabelledTextarea form-group">
-      <label className="d-block" htmlFor={props.inputId}>
+      <label className="d-block" htmlFor={props.inputId} {...labelProps}>
         {props.label}
       </label>
       <textarea
@@ -12,6 +13,7 @@ const LabelledTextarea = (props) => {
         value={props.inputText} 
         onChange={props.onChange}
         disabled={props.disabled}
+        {...other}
       />
     </div>
   );

--- a/client/src/Form/LabelledTextarea.test.js
+++ b/client/src/Form/LabelledTextarea.test.js
@@ -77,4 +77,26 @@ describe('LabelledTextarea', () => {
     );
     expect(wrapper.find('textarea').first().attr('disabled')).toBeFalsy();
   });
+
+  test('It passes the other props to the textarea', () => {
+    const wrapper = shallow(
+      <LabelledTextarea {...testData} placeholder="Enter a long text" />
+    );
+    expect(wrapper.find('label').first().prop('placeholder')).toBeUndefined();
+    expect(wrapper.find('textarea').first().prop('placeholder')).toEqual('Enter a long text');
+  });
+
+  test('It passes labelProps to the label', () => {
+    const labelProps = {
+      id: 'labelId',
+      hidden: true,
+    };
+    const wrapper = shallow(
+      <LabelledTextarea {...testData} labelProps={labelProps} />
+    );
+    expect(wrapper.find('label').first().prop('id')).toEqual(labelProps.id);
+    expect(wrapper.find('label').first().prop('hidden')).toEqual(labelProps.hidden);
+    expect(wrapper.find('textarea').first().prop('id')).not.toEqual(labelProps.id);
+    expect(wrapper.find('textarea').first().prop('hidden')).toBeUndefined();
+  });
 });

--- a/client/src/NewProjectPage/AddProjectForm/AddProjectForm.js
+++ b/client/src/NewProjectPage/AddProjectForm/AddProjectForm.js
@@ -65,6 +65,7 @@ class AddProjectForm extends Component {
           inputText={this.state.description} 
           onChange={this.handleDescriptionChange} 
           disabled={this.props.disabled}
+          rows={10}
         />
         <LabelledTagInput
           inputId="keywords" 

--- a/client/src/NewProjectPage/AddProjectForm/AddProjectForm.js
+++ b/client/src/NewProjectPage/AddProjectForm/AddProjectForm.js
@@ -58,6 +58,7 @@ class AddProjectForm extends Component {
           inputText={this.state.title} 
           onChange={this.handleTitleChange} 
           disabled={this.props.disabled}
+          placeholder="Enter a title"
         />
         <LabelledTextarea
           inputId="description" 
@@ -66,6 +67,7 @@ class AddProjectForm extends Component {
           onChange={this.handleDescriptionChange} 
           disabled={this.props.disabled}
           rows={10}
+          placeholder="Describe your project"
         />
         <LabelledTagInput
           inputId="keywords" 

--- a/client/src/NewProjectPage/AddProjectForm/AddProjectForm.test.js
+++ b/client/src/NewProjectPage/AddProjectForm/AddProjectForm.test.js
@@ -38,6 +38,7 @@ describe('AddProjectForm', () => {
     expect(wrapper.childAt(TITLE).props().label).toEqual('Title');
     expect(wrapper.childAt(DESCRIPTION).type()).toEqual(LabelledTextarea);
     expect(wrapper.childAt(DESCRIPTION).props().label).toEqual('Description');
+    expect(wrapper.childAt(DESCRIPTION).props().rows).toEqual(10);
     expect(wrapper.childAt(KEYWORDS).type()).toEqual(LabelledTagInput);
     expect(wrapper.childAt(KEYWORDS).props().label).toEqual('Keywords');
     expect(wrapper.childAt(SUBMIT).type()).toEqual('div');

--- a/client/src/NewProjectPage/NewProjectPage.js
+++ b/client/src/NewProjectPage/NewProjectPage.js
@@ -17,7 +17,7 @@ class NewProjectPage extends Component {
   render(){
     return (
       <AsyncFormPage 
-        title="Add New Project" 
+        title="Add a Project" 
         actionName="Saving" 
         redirect="/projects" 
         asyncAction={this.handleAddProject}

--- a/client/src/NewProjectPage/NewProjectPage.test.js
+++ b/client/src/NewProjectPage/NewProjectPage.test.js
@@ -13,7 +13,6 @@ describe('NewProjectPage', () => {
   test('It renders an AsyncFormPage with an AddProjectForm and the correct props', () => {
     const wrapper = shallow(<NewProjectPage />);
     expect(wrapper.type()).toEqual(AsyncFormPage);
-    expect(wrapper.hasClass('NewProjectPage')).toBe(true);
     expect(wrapper.prop('title')).toBeDefined();
     expect(wrapper.prop('title')).toEqual('Add New Project');
     expect(wrapper.prop('actionName')).toBeDefined();

--- a/client/src/NewProjectPage/NewProjectPage.test.js
+++ b/client/src/NewProjectPage/NewProjectPage.test.js
@@ -14,7 +14,7 @@ describe('NewProjectPage', () => {
     const wrapper = shallow(<NewProjectPage />);
     expect(wrapper.type()).toEqual(AsyncFormPage);
     expect(wrapper.prop('title')).toBeDefined();
-    expect(wrapper.prop('title')).toEqual('Add New Project');
+    expect(wrapper.prop('title')).toEqual('Add a Project');
     expect(wrapper.prop('actionName')).toBeDefined();
     expect(wrapper.prop('actionName')).toEqual('Saving');
     expect(wrapper.prop('asyncAction')).toBeDefined();


### PR DESCRIPTION
- increased the height of the Description box
- added placeholders for Title and Description
- added explanation for Keywords in a help text
- modified default CSS for Keywords to use the same size font as the other controls and make the tags flatter.
- changed the title of the page slightly

I gave up on adding an explanation in the Keywords placeholder and put it in a help text under the control instead. There's a potential snag if in the future someone wanted to used two LabelledTagInput components on the same page because I hard-coded the id of the help text which would cause problems if it's not unique on the page.